### PR TITLE
Implement cookie-based auth

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,0 +1,8 @@
+'use server';
+
+import { setAuthCookie } from '@/lib/auth';
+
+export async function setAuthToken(token: string) {
+  setAuthCookie(token);
+}
+

--- a/actions/letsflow.ts
+++ b/actions/letsflow.ts
@@ -3,11 +3,19 @@
 import { Process } from "@letsflow/core/process";
 import { Scenario } from "@letsflow/core/scenario";
 import { Account, ProcessSummery } from "@/lib/interfaces"
+import { getAuthCookie } from '@/lib/auth';
 
 const API_URL = process.env.LETSFLOW_API_ADDRESS ?? 'http://localhost:3000';
 
+function authHeaders() {
+  const token = getAuthCookie();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function getDemoAccounts(): Promise<Account[]> {
-  const response = await fetch(`${API_URL}/demo-accounts`);
+  const response = await fetch(`${API_URL}/demo-accounts`, {
+    headers: authHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch demo accounts', { cause: await response.text() });
@@ -17,7 +25,9 @@ export async function getDemoAccounts(): Promise<Account[]> {
 }
 
 export async function getScenarios(): Promise<Array<{ id: string, title: string, description: string}>> {
-  const response = await fetch(`${API_URL}/scenarios`);
+  const response = await fetch(`${API_URL}/scenarios`, {
+    headers: authHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch scenarios', { cause: await response.text() });
@@ -27,7 +37,9 @@ export async function getScenarios(): Promise<Array<{ id: string, title: string,
 }
 
 export async function getScenario(id: string): Promise<Scenario> {
-  const response = await fetch(`${API_URL}/scenarios/${id}`);
+  const response = await fetch(`${API_URL}/scenarios/${id}`, {
+    headers: authHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to fetch scenario '${id}'`, { cause: await response.text() });
@@ -37,7 +49,9 @@ export async function getScenario(id: string): Promise<Scenario> {
 }
 
 export async function getProcesses(): Promise<ProcessSummery[]> {
-  const response = await fetch(`${API_URL}/processes`);
+  const response = await fetch(`${API_URL}/processes`, {
+    headers: authHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch processes', { cause: await response.text() });
@@ -47,7 +61,9 @@ export async function getProcesses(): Promise<ProcessSummery[]> {
 }
 
 export async function getProcess(id: string): Promise<Process> {
-  const response = await fetch(`${API_URL}/processes/${id}`);
+  const response = await fetch(`${API_URL}/processes/${id}`, {
+    headers: authHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to fetch process '${id}'`, { cause: await response.text() });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,11 @@
-export default function Home() {
+import DemoAccounts from '@/components/demo-accounts';
+import { getDemoAccounts } from '@/actions/letsflow';
+
+export default async function Home() {
+  const accounts = await getDemoAccounts();
   return (
     <main>
-
+      <DemoAccounts accounts={accounts} />
     </main>
   );
 }

--- a/components/demo-accounts.tsx
+++ b/components/demo-accounts.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Account } from '@/lib/interfaces';
+import { setAuthToken } from '@/actions/auth';
+
+interface DemoAccountsProps {
+  accounts: Account[];
+}
+
+export default function DemoAccounts({ accounts }: DemoAccountsProps) {
+  return (
+    <ul>
+      {accounts.map((account) => (
+        <li key={account.id}>
+          <button type="button" onClick={() => setAuthToken(account.token)}>
+            {account.info.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers';
+
+export const COOKIE_NAME = 'auth-token';
+
+export function setAuthCookie(token: string) {
+  cookies().set(COOKIE_NAME, token, { httpOnly: true, sameSite: 'lax' });
+}
+
+export function getAuthCookie(): string | undefined {
+  return cookies().get(COOKIE_NAME)?.value;
+}
+


### PR DESCRIPTION
## Summary
- add helper to store auth token in a cookie
- create server action to set the cookie
- read token from cookies in API actions
- show list of demo accounts and call the new action

## Testing
- `yarn lint`
- `yarn build` *(fails: Can't resolve '@/app/page.module.css')*

------
https://chatgpt.com/codex/tasks/task_e_684cd11404188320afc39f6a6509d1f0